### PR TITLE
Auth on each request (частично 5я домашка, частично доделки 4й)

### DIFF
--- a/auth/app/controllers/accounts/sessions_controller.rb
+++ b/auth/app/controllers/accounts/sessions_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Accounts::SessionsController < Devise::SessionsController
+  def destroy
+    current_account.access_tokens.delete_all
+    super
+  end
+end

--- a/tasks/app/controllers/application_controller.rb
+++ b/tasks/app/controllers/application_controller.rb
@@ -3,20 +3,30 @@ class ApplicationController < ActionController::Base
 
   private
 
+  # Obtain fresh account data from the auth service
   def authenticate
-    if session[:account]
-      @current_account = Account.new(
-        id: session[:account]['id'],
-        email: session[:account]['email'],
-        role: session[:account]['role']
-      )
-    else
-      redirect_to '/login'
-    end
+    return redirect_to(login_url) unless session[:token_hash]
+
+    account_data = account_data(session[:token_hash])
+    @current_account = CurrentAccount.new(
+      id: account_data['id'],
+      email: account_data['email'],
+      role: account_data['role']
+    )
+  rescue OAuth2::Error
+    session[:token_hash] = nil
+    redirect_to login_url
   end
 
   def current_account
     @current_account
   end
   helper_method :current_account
+
+  def account_data(token_hash)
+    client = OmniAuth.strategies.last.new(Rails.application).client
+    access_token = OAuth2::AccessToken.from_hash(client, token_hash)
+
+    access_token.get('/accounts/current').parsed
+  end
 end

--- a/tasks/app/controllers/sessions_controller.rb
+++ b/tasks/app/controllers/sessions_controller.rb
@@ -4,18 +4,16 @@ class SessionsController < ActionController::Base
   def new
   end
 
+  # Store token in session: we'll use it later to obtain fresh account data on each
+  # request through the auth service
   def create
-    auth_data = request.env['omniauth.auth']
-    session[:account] = {
-      id: auth_data['uid'],
-      email: auth_data.dig('info', 'email'),
-      role: auth_data.dig('info', 'role')
-    }
+    access_token = request.env['omniauth.auth'].dig('info', 'token')
+    session[:token_hash] = access_token.to_hash
     redirect_to root_url
   end
 
   def destroy
-    session[:account] = nil
+    session[:token_hash] = nil
     redirect_to root_url
   end
 end

--- a/tasks/config/initializers/beak.rb
+++ b/tasks/config/initializers/beak.rb
@@ -22,11 +22,7 @@ module OmniAuth
       uid { raw_info['id'] }
 
       info do
-        {
-          id: raw_info['id']
-          email: raw_info['email'],
-          role: raw_info['role']
-        }
+        { token: access_token }
       end
 
       def raw_info


### PR DESCRIPTION
Я решил сделать синхронную аутентификацию каждого реквеста в Tasks-сервисе:
- сохраняю в сессии не данные аккаунта, а токен;
- и на каждый запрос к Tasks с помощью токена достаю актуальные данные о пользователе.

Плюсы:
- Можно разлогиниться в Auth сервисе, и это приведёт к авто-разлогиниванию на всех остальных сервисах Popug, Inc.
- Изменение роли применяется мгновенно. 

Минусы очевидны, синхронная коммуникация на каждый реквест, но ничего попишешь: быть попугом сложно.