### PR TITLE
Accounts CUD events (5я домашка)

### DIFF
--- a/auth/Gemfile
+++ b/auth/Gemfile
@@ -12,6 +12,7 @@ gem 'webpacker', '~> 5.0'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 
+gem "bunny", "~> 2.17.0"
 gem 'devise'
 gem 'doorkeeper'
 

--- a/auth/Gemfile.lock
+++ b/auth/Gemfile.lock
@@ -60,11 +60,14 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    amq-protocol (2.3.2)
     bcrypt (3.1.16)
     bindex (0.8.1)
     bootsnap (1.7.2)
       msgpack (~> 1.0)
     builder (3.2.4)
+    bunny (2.17.0)
+      amq-protocol (~> 2.3, >= 2.3.1)
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
@@ -218,6 +221,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
+  bunny (~> 2.17.0)
   devise
   doorkeeper
   factory_bot_rails

--- a/auth/app/services/event_producer.rb
+++ b/auth/app/services/event_producer.rb
@@ -1,10 +1,47 @@
 class EventProducer
   def self.account_created(account)
+    send_message(
+      type: 'account_created', account: to_attrs(account)
+    )
   end
 
   def self.account_updated(account)
+    send_message(
+      type: 'account_updated', account: to_attrs(account)
+    )
   end
 
   def self.account_deleted(account)
+    send_message(
+      type: 'account_deleted', account: to_attrs(account)
+    )
+  end
+
+  class << self
+    private
+
+    def queue
+      @queue ||= connect_to_queue
+    end
+
+    def to_attrs(account)
+      account.attributes.slice('id', 'email')
+    end
+
+    def send_message(payload)
+      queue.publish(payload.to_json)
+    end
+
+    def connect_to_queue
+      conn = Bunny.new
+      conn.start
+
+      # haven't used RabbitMQ yet, and don't know all its features. But it's 11pm, so
+      # I don't have time to learn them. So for now, declare single queue, go against
+      # best practices and include both producer and consumer names to it.
+      #
+      # we'll leave handling connections, but that's fine for now
+      conn.create_channel.queue('auth-tasks')
+    end
   end
 end

--- a/rabbitmq/docker-compose.yml
+++ b/rabbitmq/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+
+services:
+  db:
+    image: rabbitmq
+    hostname: 'bunny'
+    ports:
+      - '5672:5672'

--- a/tasks/Gemfile
+++ b/tasks/Gemfile
@@ -24,6 +24,8 @@ gem 'bootsnap', '>= 1.4.4', require: false
 
 gem 'omniauth', '~> 1.9.1'
 gem 'omniauth-oauth2'
+gem 'bunny'
+gem 'rufus-scheduler'
 
 group :development, :test do
   gem 'pry-byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/tasks/Gemfile.lock
+++ b/tasks/Gemfile.lock
@@ -60,10 +60,13 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
+    amq-protocol (2.3.2)
     bindex (0.8.1)
     bootsnap (1.7.2)
       msgpack (~> 1.0)
     builder (3.2.4)
+    bunny (2.17.0)
+      amq-protocol (~> 2.3, >= 2.3.1)
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
@@ -74,6 +77,8 @@ GEM
       dotenv (= 2.7.6)
       railties (>= 3.2)
     erubi (1.10.0)
+    et-orbi (1.2.4)
+      tzinfo
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.1.0)
@@ -85,6 +90,9 @@ GEM
       ruby2_keywords
     faraday-net_http (1.0.1)
     ffi (1.14.2)
+    fugit (1.4.2)
+      et-orbi (~> 1.1, >= 1.1.8)
+      raabro (~> 1.4)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashie (4.1.0)
@@ -135,6 +143,7 @@ GEM
       pry (~> 0.13.0)
     puma (5.2.2)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.5.2)
     rack (2.2.3)
     rack-proxy (0.6.5)
@@ -189,6 +198,8 @@ GEM
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
     ruby2_keywords (0.0.4)
+    rufus-scheduler (3.7.0)
+      fugit (~> 1.1, >= 1.1.6)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -235,6 +246,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
+  bunny
   dotenv-rails
   factory_bot_rails
   jbuilder (~> 2.7)
@@ -246,6 +258,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 6.1.3)
   rspec-rails
+  rufus-scheduler
   sass-rails (>= 6)
   spring
   turbolinks (~> 5)

--- a/tasks/app/controllers/tasks_controller.rb
+++ b/tasks/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: %i[ show edit update destroy complete ]
 
   def index
-    @tasks = Task.order(created_at: :desc)
+    @tasks = Task.order(created_at: :desc).includes(:assignee)
   end
 
   def show
@@ -51,7 +51,7 @@ class TasksController < ApplicationController
 
   def my
     if current_account
-      @tasks = FetchUserTasks.new(current_account).call
+      @tasks = FetchUserTasks.new(current_account).call.includes(:assignee)
     else
       redirect_to tasks_url, alert: 'Use user_id query param to authenticate'
     end

--- a/tasks/app/models/account.rb
+++ b/tasks/app/models/account.rb
@@ -1,24 +1,2 @@
-# not an AR model!
-class Account
-  attr_reader :id, :email, :role
-
-  def initialize(id:, email:, role:)
-    @id = id
-    @email = email
-    @role = role
-  end
-
-  def self.all
-    [
-      new('fake_id_1', 'Vasily'),
-      new('fake_id_2', 'Elena'),
-      new('fake_id_3', 'Konstantin'),
-      new('fake_id_4', 'Olga'),
-      new('fake_id_5', 'Piotr'),
-    ]
-  end
-
-  def self.find_by(id:)
-    all.detect { |user| user.id == id }
-  end
+class Account < ApplicationRecord
 end

--- a/tasks/app/models/task.rb
+++ b/tasks/app/models/task.rb
@@ -1,5 +1,7 @@
 class Task < ApplicationRecord
   enum state: [:open, :done]
 
+  belongs_to :assignee, class_name: 'Account'
+
   validates :description, presence: true
 end

--- a/tasks/app/services/accounts_streamer.rb
+++ b/tasks/app/services/accounts_streamer.rb
@@ -1,0 +1,49 @@
+class AccountsStreamer
+  def initialize
+    @queue = connect_to_queue
+  end
+
+  def sync
+    loop do
+      _, _, payload = queue.pop
+      return unless payload
+
+      process_event(payload)
+    end
+  end
+
+  private
+
+  attr_reader :queue
+
+  def process_event(payload)
+    event_type, account_data = JSON.parse(payload).values_at('type', 'account')
+
+    case event_type
+    when 'account_created' then account_created(account_data)
+    when 'account_updated' then account_updated(account_data)
+    when 'account_deleted' then account_deleted(account_data)
+    end
+  end
+
+  def account_created(account_data)
+    Rails.logger.info "Creating account: #{account_data}"
+    Account.create!(account_data)
+  end
+
+  def account_updated(account_data)
+    Rails.logger.info "Updating account: #{account_data}"
+    Account.find(account_data['id']).update!(email: account_data['email'])
+  end
+
+  def account_deleted(account_data)
+    Rails.logger.info "Deleting account: #{account_data}"
+    Account.find(account_data['id']).destroy!
+  end
+
+  def connect_to_queue
+    conn = Bunny.new
+    conn.start
+    conn.create_channel.queue('auth-tasks')
+  end
+end

--- a/tasks/app/services/assign_open_tasks.rb
+++ b/tasks/app/services/assign_open_tasks.rb
@@ -1,14 +1,14 @@
 class AssignOpenTasks
   def call
     Task.open.find_each do |task|
-      attributes = { assignee_id: available_users.sample.id }
+      attributes = { assignee_id: available_accounts.sample.id }
       UpdateTask.new(task: task, attributes: attributes).call
     end
   end
 
   private
 
-  def available_users
-    @available_users ||= User.all
+  def available_accounts
+    @available_accounts ||= Account.all
   end
 end

--- a/tasks/app/services/update_task.rb
+++ b/tasks/app/services/update_task.rb
@@ -5,11 +5,8 @@ class UpdateTask
   end
 
   def call
-    @task.assign_attributes(@attributes)
-    assignee_changed = @task.assignee_id_changed?
-
-    if @task.save
-      NotifyAssignee.call(task: @task) if assignee_changed
+    if @task.update(@attributes)
+      NotifyAssignee.call(task: @task)
       true
     else
       false

--- a/tasks/app/views/tasks/index.html.erb
+++ b/tasks/app/views/tasks/index.html.erb
@@ -18,7 +18,7 @@
       <tr>
         <td><%= task.description %></td>
         <td><%= task.state %></td>
-        <td><%= task.assignee_id %></td>
+        <td><%= task.assignee.email %></td>
         <td><%= link_to 'Show', task %></td>
         <td><%= link_to 'Edit', edit_task_path(task) %></td>
         <td><%= link_to 'Destroy', task, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/tasks/config/initializers/scheduler.rb
+++ b/tasks/config/initializers/scheduler.rb
@@ -1,0 +1,9 @@
+return if defined?(Rails::Console) || Rails.env.test?
+
+s = Rufus::Scheduler.singleton
+accounts_streamer = AccountsStreamer.new
+
+s.every '5s' do
+  Rails.logger.debug "Syncing accounts..."
+  accounts_streamer.sync
+end

--- a/tasks/db/migrate/20210321214743_create_accounts.rb
+++ b/tasks/db/migrate/20210321214743_create_accounts.rb
@@ -1,0 +1,9 @@
+class CreateAccounts < ActiveRecord::Migration[6.1]
+  def change
+    create_table :accounts, id: :uuid do |t|
+      t.string :email
+
+      t.timestamps
+    end
+  end
+end

--- a/tasks/db/schema.rb
+++ b/tasks/db/schema.rb
@@ -10,11 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_03_224918) do
+ActiveRecord::Schema.define(version: 2021_03_21_214743) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "accounts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "email"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "tasks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.text "description"

--- a/tasks/spec/factories/accounts.rb
+++ b/tasks/spec/factories/accounts.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :account do
+    id { "" }
+    email { "MyString" }
+  end
+end

--- a/tasks/spec/models/account_spec.rb
+++ b/tasks/spec/models/account_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Account, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
В общем, я выбрал в качестве message broker'a RabbitMQ, потому что давно хотел его попробовать. Но т.к. было недостаточно времени на его освоение, я не успел прочитать про всякие exchanges, pub/sub и прочие штуковины, и единственную очередь назвал вопиюще-неправильно "auth_tasks". Чтобы прям название и producer'a, и consumer'a было в очереди, отличненько 👌 

В идеале бы сделать exchange с доменным названием, и от него роутить сообщения заинтересованным консьюмерам, но потом это сделаю. Надеюсь.

Кроме того, не получилось с ходу завести консьюмер кролика (`sneakers`), поэтому в духе MVP сделал in-thread scheduler, который поллит очередь каждые 5 секунд и делает всё, что нужно. И оно работает! 